### PR TITLE
[FIX] fixed _split and add_unexpected_parts

### DIFF
--- a/models/stock_move_line.py
+++ b/models/stock_move_line.py
@@ -146,7 +146,8 @@ class StockMoveLine(models.Model):
                 if product_mls_in_serial_numbers:
                     raise ValidationError(
                             _('Serial numbers %s already exist in picking %s') %
-                            product_mls.mapped('picking_id.name'))
+                            (product_mls_in_serial_numbers.mapped('lot_name'),
+                            product_mls.mapped('picking_id.name')))
             elif product_mls:
                 # new serial numbers
                 pass

--- a/models/stock_move_line.py
+++ b/models/stock_move_line.py
@@ -318,11 +318,9 @@ class StockMoveLine(models.Model):
 
         self.write(values)
         if split:
-            ml_done = self._split()
-        else:
-            ml_done = self
-
-        return ml_done
+            self._split()
+        
+        return self
 
     def _split(self):
         """ Split the move line in self if:
@@ -349,21 +347,21 @@ class StockMoveLine(models.Model):
 
             # create new move line with the qty_done
             new_ml = self.copy(
-                default={'product_uom_qty': done_to_keep,
-                         'qty_done': qty_done,
-                         })
+                    default={'product_uom_qty': quantity_left_todo,
+                             'ordered_qty': ordered_quantity_left_todo,
+                             'qty_done': 0.0,
+                             'result_package_id': False,
+                    })
             # updated ordered_qty otherwise odoo will use product_uom_qty
-            new_ml.ordered_qty= ordered_qty
+            # new_ml.ordered_qty = ordered_quantity_left_todo
             # update self move line quantity todo
             # - bypass_reservation_update:
             #   avoids to execute code specific for Odoo UI at stock.move.line.write()
             self.with_context(bypass_reservation_update=True).write(
-                    {'product_uom_qty': quantity_left_todo,
-                     'ordered_qty': ordered_quantity_left_todo,
-                     'qty_done': 0.0,
-                     'result_package_id': False,
-                     })
-
+                        {'product_uom_qty': done_to_keep,
+                         'qty_done': qty_done,
+                         })
+            self.ordered_qty= ordered_qty
             res = new_ml
 
         return res

--- a/models/stock_picking.py
+++ b/models/stock_picking.py
@@ -64,6 +64,8 @@ class StockPicking(models.Model):
         old_move_lines = self.move_line_ids
         self._create_moves(product_quantities, confirm=True, assign=True)
         new_move_lines = (self.move_line_ids - old_move_lines)
+
+
         for ml in old_move_lines:
             if ml.qty_done > 0 and ml.product_uom_qty > ml.qty_done:
                 # Note: when adding extra moves/move_lines, odoo will merge
@@ -76,7 +78,9 @@ class StockPicking(models.Model):
 
                 # ml has qty_done 0 and new_ml is done
                 new_ml = ml._split()
-                new_move_lines |= ml
+                new_move_lines |= new_ml
+        # These are unexpected so the ordered_qty should be        
+        new_move_lines.write({"ordered_qty": 0})
 
         return new_move_lines
 


### PR DESCRIPTION
fixed _split and add_unexpected_parts so that the returned lines have ordered_qty=0 and the original move line is the one that is marked as done when over-receiving