### PR TITLE
Refs Taiga story #636 - Have added in an API endpoint for handling an…

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -12,3 +12,4 @@ from . import stock_quant
 from . import stock_quant_package
 from . import stock_warehouse
 from . import res_users
+from . import procurement

--- a/models/procurement.py
+++ b/models/procurement.py
@@ -1,0 +1,39 @@
+from odoo import models, _
+from odoo.exceptions import ValidationError
+
+
+class ProcurementGroup(models.Model):
+    _inherit = 'procurement.group'
+
+    def get_group(self, group_identifier, create=False):
+        """
+        Gets the group from the supplied group identifier - either the id
+        or the group name
+        :param group_identifier: The id or the name of the group we are
+            getting or creating
+        :param create: Boolean:  When True and group_identifier is a string
+            will create a new group if it does not exist
+        """
+        name = None
+        if isinstance(group_identifier, int):
+            domain = [('id', '=', group_identifier)]
+        elif isinstance(group_identifier, str):
+            domain = [('name', '=', group_identifier)]
+            name = group_identifier
+        else:
+            raise ValidationError(_(
+                'Unable to create domain for group search from'
+                ' identifier of type %s') % type(group_identifier))
+        results = self.search(domain)
+        if not results:
+            if create and name is not None:
+                results = self.create({'name': name})
+            else:
+                raise ValidationError(
+                    _('Group not found for '
+                      'identifier %s') % str(group_identifier))
+        if len(results) > 1:
+            raise ValidationError(
+                _('Too many groups found for '
+                  'identifier %s') % str(group_identifier))
+        return results

--- a/models/procurement.py
+++ b/models/procurement.py
@@ -26,7 +26,9 @@ class ProcurementGroup(models.Model):
                 ' identifier of type %s') % type(group_identifier))
         results = self.search(domain)
         if not results:
-            if create and name is not None:
+            if create and name:
+                # This handles name being None (i.e. not specified) but also
+                # name being a blank string (i.e. '')
                 results = self.create({'name': name})
             else:
                 raise ValidationError(

--- a/models/stock_picking.py
+++ b/models/stock_picking.py
@@ -176,6 +176,7 @@ class StockPicking(models.Model):
             result_package_id=None,
             move_parent_package=False,
             origin=None,
+            group_id=None,
     ):
         """ Creates a stock.picking and stock.moves for a given list
             of stock.quant ids
@@ -195,6 +196,8 @@ class StockPicking(models.Model):
                 Defaults to False
             @param (optional) origin: string
                 Value of the source document of the new picking
+            @param (optional) group_id: int
+                ID of the group where the stock is being assigned to
 
         """
         Picking = self.env['stock.picking']
@@ -227,6 +230,8 @@ class StockPicking(models.Model):
         }
         if origin:
             values['origin'] = origin
+        if group_id is not None:
+            values['group_id'] = group_id
         picking = Picking.create(values.copy())
 
         # Create stock.moves
@@ -715,3 +720,14 @@ class StockPicking(models.Model):
             'res_id': self.id,
             'context': dict(self.env.context),
         }
+
+    @api.multi
+    def _refine_picking(self, text=None):
+        """
+        By default refining the picking is cancel
+        """
+        for pick in self:
+            if text:
+                pick.message_post(body=_(text))
+            pick.action_cancel()
+        return

--- a/models/stock_picking.py
+++ b/models/stock_picking.py
@@ -730,4 +730,3 @@ class StockPicking(models.Model):
             if text:
                 pick.message_post(body=_(text))
             pick.action_cancel()
-        return

--- a/models/stock_picking_batch.py
+++ b/models/stock_picking_batch.py
@@ -238,7 +238,6 @@ class StockPickingBatch(models.Model):
         return all([pick.is_valid_location_dest_id(location=location)
                     for pick in all_done_pickings])
 
-    @api.multi
     def unpickable_item(self, move_line_id, reason, picking_type_id=None):
         """
         Given a valid move_line_id create a new picking of type picking_type_id

--- a/models/stock_picking_batch.py
+++ b/models/stock_picking_batch.py
@@ -244,27 +244,28 @@ class StockPickingBatch(models.Model):
     @api.multi
     def unpickable_item(self, move_line_id, reason, picking_type_id=None):
         """
-        Given a valid operation_id create a stock investigation
-        picking for it. If it is the last operation of the wave,
+        Given a valid move_line_id create a new picking of type picking_type_id
+        picking for it. If it is the last move_line_id of the wave,
         the wave is set as done.
 
-        The operation is valid if it is in the current wave (self)
+        The move_line_id is valid if it is in the current wave (self)
         and its picking is not done or cancel.
         """
-        if picking_type_id is None:
-            ResUsers = self.env['res.users']
-            picking_type_id = ResUsers.get_user_warehouse().int_type_id.id
+
         self.ensure_one()
+
+        ResUsers = self.env['res.users']
         StockMoveLine = self.env['stock.move.line']
         Picking = self.env['stock.picking']
-        Groups = self.env['procurement.group']
-        StockQuant = self.env['stock.quant']
+        Group = self.env['procurement.group']
 
         move_line = StockMoveLine.browse(move_line_id)
         picking = move_line.picking_id
         package = move_line.package_id
         location = move_line.location_id
 
+        if picking_type_id is None:
+            picking_type_id = ResUsers.get_user_warehouse().int_type_id.id
         if not move_line.exists():
             raise ValidationError(_('Cannot find the operation'))
         if picking.batch_id != self:
@@ -285,11 +286,7 @@ class StockPickingBatch(models.Model):
                          package.name, location.name)
 
         else:
-            # The move line is not part of a package.  Therefore, just get all
-            # reserved quants at the same location.
-            quants = StockQuant.search([('reserved_quantity', '>=', 0),
-                                        ('location_id', '=', location.id)])
-            move_lines = move_line
+            raise ValidationError("Not Implemented")
 
         if len(picking.move_line_ids - move_lines):
             # Create a backorder for the affected move lines if there are
@@ -301,7 +298,7 @@ class StockPickingBatch(models.Model):
         # By default the pick is cancelled
         picking._refine_picking(reason)
 
-        group = Groups.get_group(group_identifier=reason,
+        group = Group.get_group(group_identifier=reason,
                                  create=True)
 
         # create new "investigation pick"
@@ -313,7 +310,7 @@ class StockPickingBatch(models.Model):
         # If the wave does not contain any remaining picking to do, it can
         # be set as done
         remaining_pickings = self.picking_ids.filtered(
-            lambda x: x.state in ['assigned', ]
+            lambda x: x.state in ['assigned']
         )
         if not remaining_pickings.exists():
             self.state = 'done'

--- a/models/stock_picking_batch.py
+++ b/models/stock_picking_batch.py
@@ -291,7 +291,7 @@ class StockPickingBatch(models.Model):
             # move lines that are not affected
             picking = picking._create_backorder(move_lines)
 
-        # Remove the pick from the wave, and refine it
+        # Remove the pick from the batch, and refine it
         picking.batch_id = False
         # By default the pick is cancelled
         picking._refine_picking(reason)
@@ -305,7 +305,7 @@ class StockPickingBatch(models.Model):
                                picking_type_id=picking_type_id,
                                group_id=group.id)
 
-        # If the wave does not contain any remaining picking to do, it can
+        # If the batch does not contain any remaining picking to do, it can
         # be set as done
         remaining_pickings = self.picking_ids.filtered(
             lambda x: x.state in ['assigned']

--- a/models/stock_picking_batch.py
+++ b/models/stock_picking_batch.py
@@ -257,14 +257,17 @@ class StockPickingBatch(models.Model):
         Group = self.env['procurement.group']
 
         move_line = StockMoveLine.browse(move_line_id)
+        if not move_line.exists():
+            # We need to check these here lest we throw exceptions
+            # when getting picking_id, package_id etc
+            raise ValidationError(_('Cannot find the operation'))
+
         picking = move_line.picking_id
         package = move_line.package_id
         location = move_line.location_id
 
         if picking_type_id is None:
             picking_type_id = ResUsers.get_user_warehouse().int_type_id.id
-        if not move_line.exists():
-            raise ValidationError(_('Cannot find the operation'))
         if picking.batch_id != self:
             raise ValidationError(_('Move line is not part of the batch.'))
         if picking.state in ['cancel', 'done']:

--- a/models/stock_picking_batch.py
+++ b/models/stock_picking_batch.py
@@ -280,9 +280,9 @@ class StockPickingBatch(models.Model):
             # package as they will have been affected as well.
             quants = package._get_contained_quants()
             move_lines = picking.move_line_ids.get_package_move_lines(package)
-            msg = 'Unpickable package %s at location %s' % (package.name,
-                                                            location.name)
-            picking.message_post(body=_(msg))
+            msg = 'Unpickable package %s at location %s'
+
+            picking.message_post(body=_(msg) % (package.name, location.name))
 
         else:
             raise ValidationError("Not Implemented")

--- a/models/stock_picking_batch.py
+++ b/models/stock_picking_batch.py
@@ -2,9 +2,6 @@
 
 from odoo import api, models, _
 from odoo.exceptions import ValidationError
-import logging
-
-_logger = logging.getLogger(__name__)
 
 
 class StockPickingBatch(models.Model):
@@ -279,11 +276,10 @@ class StockPickingBatch(models.Model):
             # also on this package as well as all other move lines in the
             # package as they will have been affected as well.
             quants = package._get_contained_quants()
-            move_lines = picking.move_line_ids.filtered(lambda x:
-                                                        x.package_id == package)  # noqa
-
-            _logger.info('Unpickable package %s at location %s',
-                         package.name, location.name)
+            move_lines = picking.move_line_ids.get_package_move_lines(package)
+            msg = 'Unpickable package %s at location %s' % (package.name,
+                                                            location.name)
+            picking.message_post(body=_(msg))
 
         else:
             raise ValidationError("Not Implemented")

--- a/tests/test_picking_batch.py
+++ b/tests/test_picking_batch.py
@@ -319,7 +319,7 @@ class TestGoodsInPickingBatch(common.BaseUDES):
         batch.unpickable_item(move_line_id=move_line_id,
                               reason=reason,
                               picking_type_id=None)
-        picking_type = self.package_one.move_line_ids.picking_id.picking_type_id  # noqa
+        picking_type = self.package_one.find_move_lines().picking_id.picking_type_id  # noqa
 
         self.assertEqual(picking.state, 'cancel')
         self.assertEqual(batch.state, 'done')

--- a/tests/test_picking_batch.py
+++ b/tests/test_picking_batch.py
@@ -368,7 +368,8 @@ class TestGoodsInPickingBatch(common.BaseUDES):
                                location_dest_id=self.test_output_location_01.id)
         reason = 'missing item'
 
-        self.assertFalse(StockMoveLine.browse(999).exists())
+        self.assertFalse(StockMoveLine.browse(999).exists(),
+                         'Move line id=999 already exists')
         with self.assertRaisesRegex(ValidationError,
                                     'Cannot find the operation',
                                     msg='Incorrect error thrown'):

--- a/tests/test_picking_batch.py
+++ b/tests/test_picking_batch.py
@@ -484,7 +484,7 @@ class TestGoodsInPickingBatch(common.BaseUDES):
         # need to ensure that the original picking is not cancelled
         self.assertNotEqual(picking.state, 'cancel')
         # Ensure that our unpickable move_line is not in the picking
-        self.assertTrue(unpickable_move_line not in picking.move_line_ids)
+        self.assertNotIn(unpickable_move_line, picking.move_line_ids)
         self.assertEqual(new_picking.state, 'assigned')
 
     def test20_unpickable_item_multiple_move_lines_same_packages(self):

--- a/tests/test_picking_batch.py
+++ b/tests/test_picking_batch.py
@@ -354,11 +354,13 @@ class TestGoodsInPickingBatch(common.BaseUDES):
         Tests that a ValidationError is raised if the move_line_id cannot be
         found
         """
+        StockMoveLine= self.env['stock.move.line']
         picking, batch = self._create_valid_batch()
         picking.update_picking(force_validate=True,
                                location_dest_id=self.test_output_location_01.id)  # noqa
         reason = 'missing item'
 
+        self.assertFalse(StockMoveLine.browse(999).exists())
         with self.assertRaisesRegex(ValidationError,
                                     'Cannot find the operation'):
             batch.unpickable_item(move_line_id=999,
@@ -427,7 +429,7 @@ class TestGoodsInPickingBatch(common.BaseUDES):
                                   reason=reason,
                                   picking_type_id=None)
 
-    def test18_unpickable_item_no_package_vaildation_error(self):
+    def test21_unpickable_item_no_package_vaildation_error(self):
         """
         Tests that ValidationError is raised if the move_line does not have
         a package.  This functionality is not yet handled by the system.
@@ -443,7 +445,7 @@ class TestGoodsInPickingBatch(common.BaseUDES):
                                   reason=reason,
                                   picking_type_id=None)
 
-    def test19_unpickable_item_multiple_move_lines_different_packages(self):
+    def test22_unpickable_item_multiple_move_lines_different_packages(self):
         """
         Tests that a backorder is created and cancelled if there are multiple
         move lines on the picking.  The original picking should continue to
@@ -464,6 +466,7 @@ class TestGoodsInPickingBatch(common.BaseUDES):
                                       assign=True)
         batch = Batch.create_batch(None)
 
+        self.assertTrue(len(picking.move_line_ids) > 1)
         unpickable_move_line = picking.move_line_ids[0]
         unpickable_package = unpickable_move_line.package_id
 
@@ -482,7 +485,7 @@ class TestGoodsInPickingBatch(common.BaseUDES):
         self.assertNotIn(unpickable_move_line, picking.move_line_ids)
         self.assertEqual(new_picking.state, 'assigned')
 
-    def test20_unpickable_item_multiple_move_lines_same_packages(self):
+    def test23_unpickable_item_multiple_move_lines_same_packages(self):
         """
         Tests that if there are multiple move lines on the same package that
         the picking is cancelled and a new picking is created of type
@@ -503,6 +506,7 @@ class TestGoodsInPickingBatch(common.BaseUDES):
         Batch = self.env['stock.picking.batch']
         batch = Batch.create_batch(None)
 
+        self.assertTrue(len(picking.move_line_ids) > 1)
         unpickable_move_line = picking.move_line_ids[0]
         unpickable_package = unpickable_move_line.package_id
 

--- a/tests/test_picking_batch.py
+++ b/tests/test_picking_batch.py
@@ -453,7 +453,6 @@ class TestGoodsInPickingBatch(common.BaseUDES):
         move lines on the picking.  The original picking should continue to
         have the still pickable product on it.
         """
-        picking_type_internal = self.picking_type_internal
         self.create_quant(self.apple.id, self.test_location_01.id, 4,
                           package_id=self.package_one.id)
         self.create_quant(self.banana.id, self.test_location_01.id, 4,
@@ -493,7 +492,6 @@ class TestGoodsInPickingBatch(common.BaseUDES):
         the picking is cancelled and a new picking is created of type
         picking_types
         """
-        picking_type_internal = self.picking_type_internal
         self.create_quant(self.apple.id, self.test_location_01.id, 4,
                           package_id=self.package_one.id)
         self.create_quant(self.banana.id, self.test_location_01.id, 4,


### PR DESCRIPTION
… unpickable move line on a batch picking.  This will create a stock investigation for the affected move lines and create a backorder if necessary.  Also added in functionality for allowing us to get or create a ProcurementGroup