### PR TITLE
Fix validation logic for PI preceding inv adjs

### DIFF
--- a/models/stock_location.py
+++ b/models/stock_location.py
@@ -177,11 +177,11 @@ class StockLocation(models.Model):
                     _('You must specify inventory adjustments if you require '
                       'preceding adjustments.'))
 
-            pre_adjs_req = request[PRECEDING_INVENTORY_ADJUSTMENTS]
-            self._check_obj_locations(keys[:1], pre_adjs_req)
+            for pre_adjs_req in request[PRECEDING_INVENTORY_ADJUSTMENTS]:
+                self._check_obj_locations(keys[:1], pre_adjs_req)
 
-            for req in pre_adjs_req[INVENTORY_ADJUSTMENTS]:
-                self._validate_inventory_adjustment_request(req)
+                for req in pre_adjs_req[INVENTORY_ADJUSTMENTS]:
+                    self._validate_inventory_adjustment_request(req)
 
         if INVENTORY_ADJUSTMENTS in request:
             for req in request[INVENTORY_ADJUSTMENTS]:

--- a/tests/test_location_pi.py
+++ b/tests/test_location_pi.py
@@ -82,16 +82,18 @@ class TestLocationPI(common.BaseUDES):
                     'quantity': 4
                 }
             ],
-            'preceding_inventory_adjustments': {
-                'location_id': self.test_location_01.id,
-                'inventory_adjustments': [
-                    {
-                        'product_id': self.banana.id,
-                        'package_name': self.package_two,
-                        'quantity': 0
-                    }
-                ]
-            }
+            'preceding_inventory_adjustments': [
+                {
+                    'location_id': self.test_location_01.id,
+                    'inventory_adjustments': [
+                        {
+                            'product_id': self.banana.id,
+                            'package_name': self.package_two,
+                            'quantity': 0
+                        }
+                    ]
+                }
+            ]
         }
 
         self.test_location_01._validate_perpetual_inventory_request(req)
@@ -128,12 +130,14 @@ class TestLocationPI(common.BaseUDES):
                     'location_dest_id': self.test_location_02.id
                 }
             ],
-            'preceding_inventory_adjustments': {
-                'location_id': self.test_location_01.id,
-                'inventory_adjustments': [
-                    {'product_id': 7, 'package_name': 'foo', 'quantity': 0}
-                ]
-            }
+            'preceding_inventory_adjustments': [
+                {
+                    'location_id': self.test_location_01.id,
+                    'inventory_adjustments': [
+                        {'product_id': 7, 'package_name': 'foo', 'quantity': 0}
+                    ]
+                }
+            ]
         }
 
         with self.assertRaisesRegex(ValidationError,
@@ -151,16 +155,18 @@ class TestLocationPI(common.BaseUDES):
                     'quantity': 4
                 }
             ],
-            'preceding_inventory_adjustments': {
-                'location_id': self.unknown_location_id,
-                'inventory_adjustments': [
-                    {
-                        'product_id': self.banana.id,
-                        'package_name': self.package_two,
-                        'quantity': 0
-                    }
-                ]
-            }
+            'preceding_inventory_adjustments': [
+                {
+                    'location_id': self.unknown_location_id,
+                    'inventory_adjustments': [
+                        {
+                            'product_id': self.banana.id,
+                            'package_name': self.package_two,
+                            'quantity': 0
+                        }
+                    ]
+                }
+            ]
         }
 
         with self.assertRaisesRegex(ValidationError,


### PR DESCRIPTION
Here we consider the preceding inventory adjustments entry
of a PI request as an array of items. Fixing the related
unit tests.