### PR TITLE
Refs Taiga story #635 (Task #729) - Have overridden the template for …

### DIFF
--- a/views/stock_picking.xml
+++ b/views/stock_picking.xml
@@ -19,6 +19,10 @@
                     </group>
                 </group>
             </xpath>
+
+            <xpath expr="//field[@name='group_id']" position="attributes">
+                <attribute name="groups"/>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
…the procurement group display on a picking.  On odoo10 this didn't have any permission groups set for the element but on odoo11 it does.  As we want to show the procurement group (if set) at all times we have to unset the permission groups